### PR TITLE
Updated keycloak configuration

### DIFF
--- a/pages/developer-docs/installation/deploy_sb_services.md
+++ b/pages/developer-docs/installation/deploy_sb_services.md
@@ -52,6 +52,8 @@ For API keys you can refer [here](developer-docs/installation/medium_scale_deplo
 
 ## Provisioning Keycloak 
 
+**Note:** Sunbird uses Keycloak as the identity and authentication provider. 
+
 The Keycloak is deployed on a virtual machine (VM). You can deploy the Keycloak by following steps:
 
 - Run the following script to create the keycloak username, groupname and also to servicify keycloak services on VM

--- a/pages/developer-docs/installation/keycloak_realm_configuration.md
+++ b/pages/developer-docs/installation/keycloak_realm_configuration.md
@@ -7,11 +7,6 @@ description: Keycloak configuration
 published: true
 allowSearch: true
 ---
-## Getting Started
-
-A step by step guide to run and provision the keycloak server locally is explained in detail [here](http://www.keycloak.org/docs/latest/getting_started/index.html){:target="_blank"}.
-
-**Note:** Sunbird uses Keycloak as the identity and authentication provider. 
 
 ## Access Keycloak Administration
 


### PR DESCRIPTION
In keycloak configuration page, we're giving **getting started** , which we already do before using `provision-keycloak.sh` in sb_services page.