### PR TITLE
Please change the name CONTENT EDITOR to Study material

### DIFF
--- a/pages/features-documentation/contenteditor.md
+++ b/pages/features-documentation/contenteditor.md
@@ -1,9 +1,9 @@
 ---
 type: landing
 directory: features-documentation
-title: Study Material
-page_title: Study Material
-description: Study Material
+title: Content Editor
+page_title: Content Editor
+description: Features and functionality of the content editor
 keywords: content editor, create course, create content, create lesson, textbook, collection, course
 published: true
 allowSearch: true

--- a/pages/features-documentation/contenteditor.md
+++ b/pages/features-documentation/contenteditor.md
@@ -8,16 +8,18 @@ keywords: content editor, create course, create content, create lesson, textbook
 published: true
 allowSearch: true
 ---
-Sunbird has an inbuilt content editor with various features that aid in creating engaging and interesting study materials. 
-Studay materials of differnt types can be created on the content editor include: 
+Sunbird has an inbuilt content editor with various features that is used to create engaging and interesting study material. 
+Study material can be of different types like: 
 
-- Game
+- Games
 - Story
 - Worksheet
 - Quiz
 - Assessment
 
-## Prerequisite
+This page expalins the features of and how to use the content editor to create any type of Study Material. 
+
+## Prerequisites
 
 <table>
   <tr>

--- a/pages/features-documentation/contenteditor.md
+++ b/pages/features-documentation/contenteditor.md
@@ -1,15 +1,15 @@
 ---
 type: landing
 directory: features-documentation
-title: Content Editor
-page_title: Content Editor
-description: Content Editor
+title: Study Material
+page_title: Study Material
+description: Study Material
 keywords: content editor, create course, create content, create lesson, textbook, collection, course
 published: true
 allowSearch: true
 ---
-Sunbird has an inbuilt content editor with various features that aid in creating engaging and interesting content. 
-Content types created on the content editor include: 
+Sunbird has an inbuilt content editor with various features that aid in creating engaging and interesting study materials. 
+Studay materials of differnt types can be created on the content editor include: 
 
 - Game
 - Story


### PR DESCRIPTION
Please change the name CONTENT EDITOR to STUDY MATERIAL

We have links to Courses, Collection, Book, Lesson Plan etc.. But we are calling Study Material as Content Editor which is technical term user don't know what is it mean

- [ ] Have you followed [Contribution Guidelines](http://www.sunbird.org/contributions/contribution_guidelines/)

-----

